### PR TITLE
fix: remove secrets block for secrets inherit compatibility

### DIFF
--- a/.github/workflows/semantic-release-bun.yml
+++ b/.github/workflows/semantic-release-bun.yml
@@ -18,9 +18,6 @@ on:
         required: false
         default: "bun run build"
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   release:


### PR DESCRIPTION
Removes the explicit `secrets:` block from the reusable workflow.

When callers use `secrets: inherit`, having a `secrets:` block in the called workflow causes conflicts. Without the block, `secrets.GITHUB_TOKEN` is still accessible via inheritance.