### PR TITLE
feat: add Python/UV semantic-release reusable workflow

### DIFF
--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -1,0 +1,78 @@
+name: Semantic Release (Python/UV)
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version"
+        required: false
+        default: "3.13"
+        type: string
+      runner:
+        description: "GitHub Actions runner"
+        required: false
+        default: "blacksmith-4vcpu-ubuntu-2404"
+        type: string
+      pypi-publish:
+        description: "PyPI publish mode: 'true' for PyPI, 'test' for TestPyPI, 'false' to skip"
+        required: false
+        default: "false"
+        type: string
+
+jobs:
+  release:
+    name: Release
+    runs-on: ${{ inputs.runner }}
+    concurrency: release
+    permissions:
+      contents: write
+      id-token: write
+    environment:
+      name: pypi
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup uv and Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group maintain
+
+      - name: Semantic Release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          output=$(uv run semantic-release version --changelog --push --tag --vcs-release 2>&1)
+          exit_code=$?
+          set -e
+          echo "$output"
+          if echo "$output" | grep -q "No release will be made"; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          elif [ $exit_code -ne 0 ]; then
+            echo "Semantic release failed with exit code $exit_code"
+            exit $exit_code
+          else
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build package
+        if: steps.release.outputs.released == 'true'
+        run: uv build
+
+      - name: Publish to TestPyPI
+        if: steps.release.outputs.released == 'true' && inputs.pypi-publish == 'test'
+        run: uv publish --publish-url https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true' && inputs.pypi-publish == 'true'
+        run: uv publish

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+default_stages: [pre-commit]
+minimum_prek_version: "0.2.23"
+
+repos:
+  # prek builtin hooks - no network/env needed, instant execution
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+        priority: 0
+      - id: end-of-file-fixer
+        priority: 0
+      - id: check-yaml
+        priority: 0
+      - id: check-added-large-files
+        priority: 0
+      - id: check-merge-conflict
+        priority: 0
+      - id: check-case-conflict
+        priority: 0
+      - id: detect-private-key
+        priority: 0
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
+        priority: 1
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.40.0
+    hooks:
+      - id: typos
+        priority: 1
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: ["--verbose"]


### PR DESCRIPTION
Adds Python/UV semantic-release reusable workflow for Python projects using uv and python-semantic-release.

**Features:**
- Configurable Python version (default: 3.13)
- Configurable runner (default: ubuntu-latest)
- PyPI publishing support: `true` for PyPI, `test` for TestPyPI, `false` to skip
- Uses PyPI trusted publishing (no tokens needed)
- Handles 'No release will be made' gracefully

**Also includes:**
- Pre-commit hooks with prek (actionlint, typos, conventional commits)