### PR TITLE
feat: add npm-publish-bun reusable workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish-bun.yml
+++ b/.github/workflows/npm-publish-bun.yml
@@ -1,0 +1,53 @@
+name: NPM Publish (Bun)
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        required: false
+        default: "22"
+        type: string
+      bun-version:
+        description: "Bun version"
+        required: false
+        default: "latest"
+        type: string
+      build-command:
+        description: "Build command to run before publish"
+        required: false
+        default: "bun run build"
+        type: string
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: "https://registry.npmjs.org/"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: ${{ inputs.build-command }}
+
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -18,26 +18,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   release:
     uses: detailobsessed/ci-components/.github/workflows/semantic-release-bun.yml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**With custom options:**
-
-```yaml
-jobs:
-  release:
-    uses: detailobsessed/ci-components/.github/workflows/semantic-release-bun.yml@main
-    with:
-      node-version: "22"
-      bun-version: "latest"
-      build-command: "bun run build"
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit
 ```
 
 **Inputs:**
@@ -53,7 +44,50 @@ jobs:
 - `.releaserc.json` - semantic-release configuration
 - `package.json` with semantic-release dev dependencies
 
+---
+
+### NPM Publish (Bun)
+
+Publish to npm with OIDC provenance (no `NPM_TOKEN` secret needed). Triggered by GitHub releases.
+
+**Usage:**
+
+```yaml
+# .github/workflows/npm-publish.yml
+name: NPM Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    uses: detailobsessed/ci-components/.github/workflows/npm-publish-bun.yml@main
+```
+
+**Inputs:**
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `node-version` | `22` | Node.js version |
+| `bun-version` | `latest` | Bun version |
+| `build-command` | `bun run build` | Build command to run before publish |
+
+**Prerequisites:**
+
+1. Configure npm trusted publishing for your package at [npmjs.com](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)
+2. Set `"publishConfig": { "access": "public" }` in `package.json` for scoped packages
+
+---
+
 ## Setup for New Projects
+
+### GitHub-only releases (no npm)
 
 1. Add `.releaserc.json`:
 
@@ -80,4 +114,11 @@ jobs:
 bun add -d semantic-release @semantic-release/changelog @semantic-release/git
 ```
 
-3. Create workflow file calling this reusable workflow.
+3. Create `release.yml` workflow calling the semantic-release workflow.
+
+### With npm publishing
+
+Use the same setup as above, plus:
+
+4. Create `npm-publish.yml` workflow calling the npm-publish workflow.
+5. Configure npm trusted publishing for your GitHub repo.


### PR DESCRIPTION
## Summary

Adds a new reusable workflow for publishing packages to npm using **OIDC trusted publishing** - no `NPM_TOKEN` secret required.

## Changes

- **New workflow**: `npm-publish-bun.yml` - reusable workflow for npm publishing
- **Updated README**: Documents both semantic-release and npm-publish workflows with setup instructions

## How it works

1. Uses `id-token: write` permission to enable GitHub OIDC
2. npm CLI auto-detects OIDC environment and authenticates without tokens
3. Provenance attestations are automatically generated for public repos

## Usage

```yaml
# .github/workflows/npm-publish.yml
name: NPM Publish

on:
  release:
    types: [published]

permissions:
  id-token: write
  contents: read

jobs:
  publish:
    uses: detailobsessed/ci-components/.github/workflows/npm-publish-bun.yml@main
```

## Prerequisites

1. Configure [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) for your package at npmjs.com
2. Set `"publishConfig": { "access": "public" }` in `package.json` for scoped packages