### PR TITLE
fix: remove --provenance flag, trusted publishing auto-generates provenance

### DIFF
--- a/.github/workflows/npm-publish-bun.yml
+++ b/.github/workflows/npm-publish-bun.yml
@@ -49,5 +49,7 @@ jobs:
       - name: Build
         run: ${{ inputs.build-command }}
 
-      - name: Publish to npm with provenance
-        run: npm publish --access public --provenance
+      - name: Publish to npm
+        # Uses OIDC trusted publishing - no NPM_TOKEN needed
+        # Provenance is automatically generated for public repos/packages
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ jobs:
 
 **Prerequisites:**
 
-1. Configure npm trusted publishing for your package at [npmjs.com](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)
+1. Configure [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) for your package at npmjs.com
 2. Set `"publishConfig": { "access": "public" }` in `package.json` for scoped packages
+
+**Note:** Provenance attestations are automatically generated when publishing via trusted publishing from public repos.
 
 ---
 


### PR DESCRIPTION
### TL;DR

Updated npm publishing workflow to use trusted publishing without explicit provenance flag.

### What changed?

- Removed the `--provenance` flag from the npm publish command in the GitHub workflow
- Added clarifying comments in the workflow about OIDC trusted publishing and automatic provenance generation
- Updated the README documentation to reference npm trusted publishing more clearly
- Added a note in the README explaining that provenance attestations are automatically generated for public repos

### How to test?

1. Use this workflow to publish a package to npm
2. Verify the package is published correctly with provenance attestations
3. Confirm no NPM_TOKEN is needed when using the trusted publishing setup

### Why make this change?

The `--provenance` flag is redundant when using npm's trusted publishing with GitHub Actions, as provenance is automatically generated for public repositories and packages. This change simplifies the publishing command while maintaining the security benefits of supply chain attestations.