### PR TITLE
fix: use ubuntu-latest for npm publish (provenance requires GitHub-hosted runners)

### DIFF
--- a/.github/workflows/npm-publish-bun.yml
+++ b/.github/workflows/npm-publish-bun.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   publish:
     name: Publish to npm
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Reverts npm-publish workflow to use `ubuntu-latest` instead of Blacksmith runners.

## Problem

While Blacksmith runners work for OIDC authentication, npm's **provenance verification** rejects them:

```
Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
```

Blacksmith runners are classified as "self-hosted" by npm, even though they're cloud-hosted.

## Solution

Use `ubuntu-latest` (GitHub-hosted) for npm-publish to ensure provenance attestations work correctly.

## Trade-off

Slightly slower builds, but maintains supply chain security with provenance attestations.