### PR TITLE
feat: add MCP Registry publish and auto-merge Dependabot workflows

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,55 @@
+name: Auto Merge Dependabot
+
+on:
+  workflow_call:
+    inputs:
+      merge-method:
+        description: "Merge method (merge, squash, rebase)"
+        required: false
+        default: "merge"
+        type: string
+      update-types:
+        description: "Update types to auto-merge (comma-separated: minor,patch)"
+        required: false
+        default: "minor,patch"
+        type: string
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if update type should be auto-merged
+        id: check
+        run: |
+          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+          ALLOWED_TYPES="${{ inputs.update-types }}"
+          
+          SHOULD_MERGE="false"
+          if [[ "$ALLOWED_TYPES" == *"minor"* ]] && [[ "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
+            SHOULD_MERGE="true"
+          fi
+          if [[ "$ALLOWED_TYPES" == *"patch"* ]] && [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]]; then
+            SHOULD_MERGE="true"
+          fi
+          
+          echo "should-merge=$SHOULD_MERGE" >> $GITHUB_OUTPUT
+
+      - name: Auto-merge
+        if: steps.check.outputs.should-merge == 'true'
+        run: gh pr merge --auto --${{ inputs.merge-method }} "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mcp-registry-publish-bun.yml
+++ b/.github/workflows/mcp-registry-publish-bun.yml
@@ -1,0 +1,31 @@
+name: MCP Registry Publish (Bun)
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "Runner to use (Blacksmith works with OIDC)"
+        required: false
+        default: "blacksmith-4vcpu-ubuntu-2404"
+        type: string
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         priority: 1
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
+    rev: v1.40.1
     hooks:
       - id: typos
         priority: 1


### PR DESCRIPTION
## Summary

Adds two new reusable workflows extracted from efficient-gitlab-mcp:

## New Workflows

### MCP Registry Publish (`mcp-registry-publish-bun.yml`)
Publishes MCP servers to the official MCP Registry using GitHub OIDC authentication.

- Uses Blacksmith runner (OIDC works there)
- Downloads `mcp-publisher` CLI from official releases
- Authenticates via `github-oidc` method

### Auto Merge Dependabot (`auto-merge-dependabot.yml`)
Automatically merges Dependabot PRs for minor and patch updates.

- Configurable merge method (merge/squash/rebase)
- Configurable update types to auto-merge
- Uses `dependabot/fetch-metadata` to detect update type

## Changes

- Added `.github/workflows/mcp-registry-publish-bun.yml`
- Added `.github/workflows/auto-merge-dependabot.yml`
- Updated README with usage documentation for both workflows