### PR TITLE
docs: update npm-publish usage to use workflow_run trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ This prevents broken commits from being released before CI catches failures.
 
 ### NPM Publish (Bun)
 
-Publish to npm with OIDC provenance (no `NPM_TOKEN` secret needed). Triggered by GitHub releases.
+Publish to npm with OIDC provenance (no `NPM_TOKEN` secret needed).
+
+> **⚠️ Important:** Do NOT use `on: release: types: [published]` as the trigger. Releases created with `GITHUB_TOKEN` (which semantic-release uses) do NOT emit `release` events. Use `workflow_run` instead.
 
 **Usage:**
 
@@ -86,8 +88,10 @@ Publish to npm with OIDC provenance (no `NPM_TOKEN` secret needed). Triggered by
 name: NPM Publish
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -96,6 +100,7 @@ permissions:
 
 jobs:
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: detailobsessed/ci-components/.github/workflows/npm-publish-bun.yml@main
 ```
 


### PR DESCRIPTION
## Summary

Updates the NPM Publish documentation to use `workflow_run` trigger instead of `release: published`.

## Why

**Releases created with `GITHUB_TOKEN` do NOT emit `release` events** to trigger other workflows. This is a GitHub security feature to prevent infinite loops.

When semantic-release creates a release using `GITHUB_TOKEN`, the `on: release: types: [published]` trigger will never fire.

## Solution

Use `workflow_run` trigger to chain NPM Publish after the Release workflow completes:

```yaml
on:
  workflow_run:
    workflows: ["Release"]
    branches: [main]
    types: [completed]
```

## Source

- [semantic-release/github](https://github.com/semantic-release/github): "However releases done with this token will NOT trigger release events to start other workflows."