### PR TITLE
feat: expose released output from semantic-release-uv workflow

### DIFF
--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: "false"
         type: string
+    outputs:
+      released:
+        description: "Whether a new release was created"
+        value: ${{ jobs.release.outputs.released }}
 
 jobs:
   release:
@@ -29,6 +33,8 @@ jobs:
       id-token: write
     environment:
       name: pypi
+    outputs:
+      released: ${{ steps.release.outputs.released }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Enables calling workflows to conditionally run PyPI publish in a separate
job, which is required for trusted publishing (can't work from reusable workflows).