### PR TITLE
fix: checkout latest release tag in MCP Registry publish workflow

### DIFF
--- a/.github/workflows/mcp-registry-publish-bun.yml
+++ b/.github/workflows/mcp-registry-publish-bun.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: "blacksmith-4vcpu-ubuntu-2404"
         type: string
+      default-branch:
+        description: "Default branch to fetch latest release tag from"
+        required: false
+        default: "main"
+        type: string
 
 jobs:
   publish:
@@ -19,6 +24,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.default-branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout latest release tag
+        run: git checkout "$(git describe --tags --abbrev=0)"
 
       - name: Install mcp-publisher
         run: |

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ uv publish --token "$(op read op://Personal/pypi-token/credential)"
 
 Publish MCP servers to the [official MCP Registry](https://registry.modelcontextprotocol.io/) using OIDC authentication.
 
-**Usage:**
+**Usage (standalone workflow — npm projects):**
 
 ```yaml
 # .github/workflows/mcp-registry-publish.yml
@@ -278,11 +278,24 @@ jobs:
     uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish-bun.yml@main
 ```
 
+**Usage (inline job — Python/UV projects):**
+
+For Python projects using `semantic-release-uv.yml`, add MCP Registry publish as a job in `release.yml` gated on `released == 'true'` to avoid duplicate-version errors:
+
+```yaml
+# Inside release.yml, alongside pypi-publish
+  mcp-registry-publish:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: detailobsessed/ci-components/.github/workflows/mcp-registry-publish-bun.yml@main
+```
+
 **Inputs:**
 
 | Input | Default | Description |
 |-------|---------|-------------|
 | `runner` | `blacksmith-4vcpu-ubuntu-2404` | Runner to use (Blacksmith works with OIDC) |
+| `default-branch` | `main` | Default branch to fetch latest release tag from |
 
 **Prerequisites:**
 


### PR DESCRIPTION
## Problem

The reusable workflow `mcp-registry-publish-bun.yml` does a plain `actions/checkout` which checks out `github.sha` — the commit that triggered the workflow chain (e.g., the PR merge commit). This is **not** the release commit where semantic-release bumped `server.json`.

Result: `mcp-publisher publish` reads the old `server.json` version and gets `400: cannot publish duplicate version`.

## Fix

- Fetch full history + tags from the default branch
- Checkout the latest release tag (`git describe --tags --abbrev=0`)
- Add `default-branch` input (defaults to `main`) for repos using different branch names

This matches the pattern used by `pypi-publish` jobs that checkout the latest tag before building.

## Docs

- Added Python/UV inline job usage pattern for `release.yml`
- Added `default-branch` input to the inputs table
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/ci-components/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
