### PR TITLE
fix: make dependency group configurable in semantic-release-uv workflow

### DIFF
--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "blacksmith-4vcpu-ubuntu-2404"
         type: string
+      dependency-group:
+        description: "UV dependency group containing python-semantic-release"
+        required: false
+        default: "maintain"
+        type: string
       pypi-publish:
         description: "PyPI publish mode: 'true' for PyPI, 'test' for TestPyPI, 'false' to skip"
         required: false
@@ -50,7 +55,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group maintain
+        env:
+          DEP_GROUP: ${{ inputs.dependency-group }}
+        run: uv sync --group "$DEP_GROUP"
 
       - name: Semantic Release
         id: release


### PR DESCRIPTION
## Summary
Make the UV dependency group configurable in the semantic-release-uv reusable workflow.

## Problem
The workflow hardcoded `uv sync --group maintain`, which fails for projects that have `python-semantic-release` in a different dependency group (e.g., `dev`). This broke the release workflow for copier-uv-bleeding (the template repo itself).

## Solution
Add a `dependency-group` input parameter (default: `maintain`) so callers can specify which group contains `python-semantic-release`.

## Changes
- `.github/workflows/semantic-release-uv.yml`: add `dependency-group` input, use it in install step
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/ci-components/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
