### PR TITLE
feat: make python-version a required input for semantic-release-uv

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -24,11 +24,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.default-branch }}
           fetch-depth: 0

--- a/.github/workflows/npm-publish-bun.yml
+++ b/.github/workflows/npm-publish-bun.yml
@@ -28,17 +28,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
           bun-version: ${{ inputs.bun-version }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://registry.npmjs.org/"

--- a/.github/workflows/semantic-release-bun.yml
+++ b/.github/workflows/semantic-release-bun.yml
@@ -29,17 +29,17 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
           bun-version: ${{ inputs.bun-version }}
 

--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -4,9 +4,8 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: "Python version"
-        required: false
-        default: "3.13"
+        description: "Python version (must match your project's requires-python)"
+        required: true
         type: string
       runner:
         description: "GitHub Actions runner"
@@ -51,13 +50,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
           python-version: ${{ inputs.python-version }}
           enable-cache: true

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
     with:
+      python-version: "3.14"  # Must match your project's requires-python
       # MUST be "false" when using trusted publishing — see pypi-publish job below
       pypi-publish: "false"
     # Pass GITHUB_TOKEN to the reusable workflow
@@ -330,13 +331,16 @@ If your project is an MCP server, see [MCP Registry Publish](#mcp-registry-publi
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `python-version` | `3.13` | Python version |
+| `python-version` | **required** | Python version (must match your project's `requires-python`) |
 | `runner` | `blacksmith-4vcpu-ubuntu-2404` | GitHub Actions runner |
+| `dependency-group` | `maintain` | UV dependency group containing `python-semantic-release` |
 | `pypi-publish` | `false` | PyPI publish mode: `true`, `test`, or `false` (use `false` with trusted publishing) |
 
 | Output | Description |
 |--------|-------------|
 | `released` | `true` if a new release was created, `false` otherwise |
+| `version` | The released version (e.g. `1.2.3`) — only set when `released` is `true` |
+| `tag` | The release tag (e.g. `v1.2.3`) — only set when `released` is `true` |
 
 **Required in calling repo:**
 

--- a/prek.toml
+++ b/prek.toml
@@ -6,23 +6,23 @@ default_install_hook_types = ["commit-msg", "pre-commit", "pre-push"]
 [[repos]]
 repo = "builtin"
 hooks = [
-  { id = "no-commit-to-branch", args = ["--branch", "main"], priority = 0 },
-  { id = "trailing-whitespace", priority = 0 },
-  { id = "end-of-file-fixer", priority = 0 },
-  { id = "check-yaml", args = ["--allow-multiple-documents"], priority = 0 },
-  { id = "check-toml", priority = 0 },
-  { id = "check-added-large-files", priority = 0 },
-  { id = "check-merge-conflict", priority = 0 },
-  { id = "check-case-conflict", priority = 0 },
-  { id = "check-symlinks", priority = 0 },
-  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
-  { id = "detect-private-key", priority = 0 },
+  { id = "no-commit-to-branch", args = ["--branch", "main"], stages = ["pre-commit"], priority = 0 },
+  { id = "trailing-whitespace", stages = ["pre-commit"], priority = 0 },
+  { id = "end-of-file-fixer", stages = ["pre-commit"], priority = 0 },
+  { id = "check-yaml", args = ["--allow-multiple-documents"], stages = ["pre-commit"], priority = 0 },
+  { id = "check-toml", stages = ["pre-commit"], priority = 0 },
+  { id = "check-added-large-files", stages = ["pre-commit"], priority = 0 },
+  { id = "check-merge-conflict", stages = ["pre-commit"], priority = 0 },
+  { id = "check-case-conflict", stages = ["pre-commit"], priority = 0 },
+  { id = "check-symlinks", stages = ["pre-commit"], priority = 0 },
+  { id = "mixed-line-ending", args = ["--fix=lf"], stages = ["pre-commit"], priority = 0 },
+  { id = "detect-private-key", stages = ["pre-commit"], priority = 0 },
 ]
 
 [[repos]]
 repo = "https://github.com/gitleaks/gitleaks"
 rev = "v8.30.0"
-hooks = [{ id = "gitleaks", priority = 1 }]
+hooks = [{ id = "gitleaks", stages = ["pre-commit"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
@@ -47,14 +47,20 @@ hooks = [
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
 rev = "v1.7.10"
-hooks = [{ id = "actionlint", priority = 1 }]
+hooks = [{ id = "actionlint", stages = ["pre-commit"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.43.3"
-hooks = [{ id = "typos", priority = 1 }]
+rev = "v1.43.4"
+hooks = [{ id = "typos", stages = ["pre-commit"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.47.0"
-hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
+hooks = [{ id = "markdownlint", args = ["--fix"], stages = ["pre-commit"], priority = 1 }]
+
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "actions-up", name = "Check GitHub Actions updates", language = "system", entry = "env CI=true actions-up --dry-run --yes", stages = ["pre-push"], priority = 1 },
+]


### PR DESCRIPTION
## Summary

Make `python-version` a required input for `semantic-release-uv.yml`, preventing silent failures when a project's `requires-python` doesn't match the old default (`3.13`).

## Changes

- **`semantic-release-uv.yml`**: Remove `default: "3.13"`, set `required: true`
- **`README.md`**: Update quick-start example, add `dependency-group` to inputs table, add `version`/`tag` to outputs table, add `actions-up` tip to Gotchas
- **`prek.toml`**: Add explicit `stages` to all hooks, update `default_install_hook_types`, bump action versions via `actions-up`

## Breaking Change

Existing callers that rely on the default `python-version` will fail until they add `python-version` to their `with:` block. This is intentional — the whole point is to surface mismatches early.

Closes #16