### PR TITLE
fix: add github-token to setup-uv to prevent API rate limiting

### DIFF
--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           enable-cache: true
+          # Required: without this, setup-uv resolves the latest version via
+          # anonymous GitHub API calls which get rate-limited on shared runners.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         env:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ jobs:
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: uv build
       - run: uv publish


### PR DESCRIPTION
## Problem

`setup-uv@v7` falls back to the GitHub API to resolve the latest uv version when it can't find one in `uv.toml` or `pyproject.toml`. Without `github-token`, these API calls are anonymous and get rate-limited on shared runners:

```
No (valid) GitHub token provided. Falling back to anonymous. Requests might be rate limited.
Error: API rate limit exceeded for 54.177.159.230.
```

This broke the codereviewbuddy release workflow (run `22106780876`).

## Fix

Pass `github-token: ${{ secrets.GITHUB_TOKEN }}` to `setup-uv` in the `semantic-release-uv.yml` reusable workflow and in the README pypi-publish example.

`secrets.GITHUB_TOKEN` is automatically available in workflow runs — no configuration needed by consumers.