### PR TITLE
fix: use --no-default-groups for leaner release CI installs

### DIFF
--- a/.github/workflows/semantic-release-uv.yml
+++ b/.github/workflows/semantic-release-uv.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         env:
           DEP_GROUP: ${{ inputs.dependency-group }}
-        run: uv sync --group "$DEP_GROUP"
+        run: uv sync --no-default-groups --group "$DEP_GROUP"
 
       - name: Semantic Release
         id: release


### PR DESCRIPTION
## Why

`uv sync --group maintain` installs all default groups (dev, test, docs, etc.) plus maintain — far more than semantic-release needs. The template already switched to `--no-default-groups --group maintain` in 0.33.11.

## Changes

- `semantic-release-uv.yml` — `uv sync --group` → `uv sync --no-default-groups --group` for leaner, faster release CI